### PR TITLE
fix: text overlap in QGroupBox and QTabBar

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -189,6 +189,7 @@ QTabBar::tab
 {
     background-color: #282a36;
     border-radius: 3px;
+    padding: 4px;
 }
 
 QTabBar::tab:selected
@@ -417,6 +418,14 @@ QTreeView
 QGroupBox
 {
     margin-top: 5px;
+}
+
+QGroupBox::title
+{
+    subcontrol-origin: margin;
+    subcontrol-position: top left;
+    left: 7px;
+    padding: 0px 4px 0px 6px;
 }
 
 


### PR DESCRIPTION
this adds a padding of 4px to QTabBar tabs so that they are not so closely placed together
<details>
<summary>before/after</summary>

![before](https://user-images.githubusercontent.com/59253100/155341229-dd5f6994-974a-43f5-933c-bfeb4ad4186d.png)

![after](https://user-images.githubusercontent.com/59253100/155341376-1329baa1-4110-4872-8da1-95b0551521f3.png)
</details>

adds QGroupBox title styling so that it is not randomly placed inside the group box
<details>
<summary>before/after</summary>

![before](https://user-images.githubusercontent.com/59253100/155341728-6a1d49ba-8f3c-4273-b56b-bc00dc49fda6.png)

![after](https://user-images.githubusercontent.com/59253100/155341666-509f5edc-c6bc-4177-9e6d-87d468bffb67.png)
</details>

Fixes #5