### PR TITLE
fix: filter highlight color

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -86,6 +86,13 @@ CustomIDAMemo
 
 }
 
+/* search filter */
+TChooser
+{
+    qproperty-highlight-bg-default: #bd93f9;
+    qproperty-highlight-bg-selected: #bd93f9;
+}
+
 MainMsgList
 {
     color: #f8f8f2;


### PR DESCRIPTION
changes highlighting from unreadable background color in TChooser (e.g. strings/segments/functions views) to theme color

<details>
<summary>before/after</summary>

![image](https://user-images.githubusercontent.com/59253100/155854911-af64014e-3f58-4e96-a2e8-7204c0a7ba27.png)

![image](https://user-images.githubusercontent.com/59253100/155854918-19947c12-4849-424d-8a0e-abeae99b226c.png)

</details>